### PR TITLE
Simple Bugfix: `from array import array` => `import array`

### DIFF
--- a/src/pyfasttext.pyx
+++ b/src/pyfasttext.pyx
@@ -17,7 +17,7 @@ from libcpp.set cimport set
 from libcpp.utility cimport pair
 from libcpp.queue cimport priority_queue
 
-from array import array
+import array
 
 cdef extern from "<iostream>" namespace "std" nogil:
   cdef cppclass istream:


### PR DESCRIPTION
The import statement `from array import array` is incompatible with the line `arr = array.array('f')` in `__getitem__()`.  
This caused all lookups `model[key]` to raise exceptions.

This pull request fixes the problem.